### PR TITLE
Ruby 3.0 fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,25 @@ jobs:
 workflows:
   ci:
     jobs:
+
+      # Ruby 3.0 release
+      - bundle_and_test:
+          name: "ruby3-0_rails6-1"
+          ruby_version: 3.0.0
+          rails_version: 6.1.1
+      - bundle_and_test:
+          name: "ruby3-0_rails6-0"
+          ruby_version: 3.0.0
+          rails_version: 6.0.2
+      - bundle_and_test:
+          name: "ruby3-0_rails5-2"
+          ruby_version: 3.0.0
+          rails_version: 5.2.6
+      - bundle_and_test:
+          name: "ruby3-0_rails5-1"
+          ruby_version: 3.0.0
+          rails_version: 5.1.7
+
       # Ruby 2.7 release
       - bundle_and_test:
           name: "ruby2-7_rails6-1"
@@ -66,7 +85,7 @@ workflows:
       - bundle_and_test:
           name: "ruby2-7_rails5-2"
           ruby_version: 2.7.5
-          rails_version: 5.2.4
+          rails_version: 5.2.6
       - bundle_and_test:
           name: "ruby2-7_rails5-1"
           ruby_version: 2.7.5
@@ -84,7 +103,7 @@ workflows:
       - bundle_and_test:
           name: "ruby2-6_rails5-2"
           ruby_version: 2.6.9
-          rails_version: 5.2.4
+          rails_version: 5.2.6
       - bundle_and_test:
           name: "ruby2-6_rails5-1"
           ruby_version: 2.6.9
@@ -94,7 +113,7 @@ workflows:
       - bundle_and_test:
           name: "ruby2-5_rails6-1"
           ruby_version: 2.5.9
-          rails_version: 6.1.0
+          rails_version: 6.1.1
       - bundle_and_test:
           name: "ruby2-5_rails6-0"
           ruby_version: 2.5.9
@@ -102,7 +121,7 @@ workflows:
       - bundle_and_test:
           name: "ruby2-5_rails5-2"
           ruby_version: 2.5.9
-          rails_version: 5.2.4
+          rails_version: 5.2.6
       - bundle_and_test:
           name: "ruby2-5_rails5-1"
           ruby_version: 2.5.9
@@ -130,7 +149,7 @@ workflows:
       - bundle_and_test:
           name: "ruby2-7_rails5-2"
           ruby_version: 2.7.5
-          rails_version: 5.2.4
+          rails_version: 5.2.6
       - bundle_and_test:
           name: "ruby2-7_rails5-1"
           ruby_version: 2.7.5
@@ -158,7 +177,7 @@ workflows:
       - bundle_and_test:
           name: "ruby2-5_rails6-1"
           ruby_version: 2.5.9
-          rails_version: 6.1.0
+          rails_version: 6.1.1
       - bundle_and_test:
           name: "ruby2-5_rails6-0"
           ruby_version: 2.5.9

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,7 @@ inherit_gem:
 inherit_from: .rubocop_todo.yml
 
 AllCops:
+  NewCops: disable # for now.
   TargetRubyVersion: 2.6
   DisplayCopNames: true
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gemspec path: File.expand_path('..', __FILE__)
 group :development, :test do
   gem 'coveralls', require: false
   gem 'simplecov', require: false
+  gem 'ldpath', git: 'git@github.com:/samvera-labs/ldpath.git', branch: '3_0_tests'
 end
 
 # BEGIN ENGINE_CART BLOCK

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,8 @@ gemspec path: File.expand_path('..', __FILE__)
 group :development, :test do
   gem 'coveralls', require: false
   gem 'simplecov', require: false
-  gem 'ldpath', git: 'git@github.com:/samvera-labs/ldpath.git', branch: 'main'
+  # Temporarily pointing to the 3.1-compatible ldpath branch.
+  gem 'ldpath', git: 'git@github.com:/samvera-labs/ldpath.git', branch: '3_1_tests'
 end
 
 # BEGIN ENGINE_CART BLOCK

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec path: File.expand_path('..', __FILE__)
 group :development, :test do
   gem 'coveralls', require: false
   gem 'simplecov', require: false
-  gem 'ldpath', git: 'git@github.com:/samvera-labs/ldpath.git', branch: '3_0_tests'
+  gem 'ldpath', git: 'git@github.com:/samvera-labs/ldpath.git', branch: 'main'
 end
 
 # BEGIN ENGINE_CART BLOCK

--- a/Rakefile
+++ b/Rakefile
@@ -8,6 +8,10 @@ RSpec::Core::RakeTask.new(:spec)
 
 desc 'Run style checker'
 RuboCop::RakeTask.new(:rubocop) do |task|
+  
+  # Just for now as we fix this up:
+  task.options = ['--fail-fast']
+
   task.requires << 'rubocop-rspec'
   task.fail_on_error = true
 end

--- a/Rakefile
+++ b/Rakefile
@@ -18,6 +18,6 @@ task ci: ['engine_cart:generate'] do
 end
 
 desc 'Run continuous integration build'
-task ci: ['rubocop', 'spec']
+task ci: [ 'spec']
 
 task default: :ci

--- a/Rakefile
+++ b/Rakefile
@@ -18,6 +18,6 @@ task ci: ['engine_cart:generate'] do
 end
 
 desc 'Run continuous integration build'
-task ci: [ 'spec']
+task ci: ['rubocop', 'spec']
 
 task default: :ci

--- a/lib/qa/authorities/linked_data/find_term.rb
+++ b/lib/qa/authorities/linked_data/find_term.rb
@@ -136,7 +136,7 @@ module Qa::Authorities
         # Special processing for loc ids for backward compatibility.  IDs may be in the form 'n123' or 'n 123'.  This adds
         # the <blank> into the ID to allow it to be found as the object of a triple in the graph.
         def loc_id
-          loc_id = URI.unescape(id)
+          loc_id = CGI.unescape(id)
           digit_idx = loc_id.index(/\d/)
           loc_id.insert(digit_idx, ' ') if loc? && loc_id.index(' ').blank? && digit_idx > 0
           loc_id
@@ -164,7 +164,7 @@ module Qa::Authorities
         def extract_uri_by_id(id_predicate)
           @uri = graph_service.subjects_for_object_value(graph: @filtered_graph,
                                                          predicate: id_predicate,
-                                                         object_value: URI.unescape(id)).first
+                                                         object_value: CGI.unescape(id)).first
           return if @uri.present? || !loc?
 
           # NOTE: Second call to try and extract using the loc_id allows for special processing on the id for LOC authorities.
@@ -172,7 +172,7 @@ module Qa::Authorities
           #       the ID is provided without the <blank>, this tries a second time to find it with the <blank>.
           @uri = graph_service.subjects_for_object_value(graph: @filtered_graph,
                                                          predicate: id_predicate,
-                                                         object_value: URI.unescape(loc_id)).first
+                                                         object_value: CGI.unescape(loc_id)).first
           return if @uri.blank? # only show the depercation warning if the loc_id was used
           Qa.deprecation_warning(
             in_msg: 'Qa::Authorities::LinkedData::FindTerm',

--- a/lib/qa/authorities/oclcts/generic_oclc_authority.rb
+++ b/lib/qa/authorities/oclcts/generic_oclc_authority.rb
@@ -34,7 +34,7 @@ module Qa::Authorities
 
       def get_raw_response(query_type, id)
         query_url = Oclcts.url_pattern(query_type).gsub("{query}", id).gsub("{id}", id).gsub("{authority-id}", subauthority)
-        @raw_response = Nokogiri::XML(open(query_url))
+        @raw_response = Nokogiri::XML(URI.open(query_url))
       end
   end
 end

--- a/qa.gemspec
+++ b/qa.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rdf'
 
   # the hyrax style guide is based on `bixby`. see `.rubocop.yml`
-  s.add_development_dependency 'bixby', '~> 3.0.0'
+  s.add_development_dependency 'bixby', '~> 5.0', '>= 5.0.2' # bixby 5 briefly dropped Ruby 2.5
   s.add_development_dependency 'rails', '!=5.2.0', '!=5.2.1', '!=5.2.2'
   s.add_development_dependency 'byebug'
   s.add_development_dependency 'engine_cart', '~> 2.0'


### PR DESCRIPTION
`rake ci` passes against Ruby 3.0 after the following changes:
- Use a patched version of ldpath that works with 3.0
- `URI.escape` and `URI.unescape` become `CGI.escape` and `CGI.unescape`
- In `GenericOclcAuthority`, open URI using `URI.open`, not `open`.